### PR TITLE
Bug/remove monolog utils dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/netsells/netsells-logger-php/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/netsells/netsells-logger-php/releases/tag/v1.0.0
+[1.0.1]: https://github.com/netsells/netsells-logger-php/releases/tag/v1.0.1

--- a/src/LaravelLogger.php
+++ b/src/LaravelLogger.php
@@ -161,11 +161,11 @@ class LaravelLogger implements FormatterInterface
     protected function normalizeException($e)
     {
         if (!$e instanceof \Exception && !$e instanceof \Throwable) {
-            throw new \InvalidArgumentException('Exception/Throwable expected, got '.gettype($e).' / '.Utils::getClass($e));
+            throw new \InvalidArgumentException('Exception/Throwable expected, got '.gettype($e).' / '.get_class($e));
         }
 
         $data = array(
-            'type' => Utils::getClass($e),
+            'type' => get_class($e),
             'message' => $e->getMessage(),
             'code' => (int) $e->getCode(),
             'source' => $e->getFile().':'.$e->getLine(),


### PR DESCRIPTION
## Overview
- [x ] I have performed a self review of my code
- [ x] I have made corresponding changes to the documentation
- [ x] I have commented my code, particularly in hard-to-understand areas
<!-- Remove the below if this project doesn't have tests (maybe it should?) -->
- [ x] New and existing tests pass locally with my changes
- [ x] The code modified as part of this PR has been covered with tests

### Problem statement
<!-- Description of the problem -->
`Utils::class` in the monolog package has been namespaced in more recent versions. This was causing an error to be thrown (and nothing to be logged). 

### Solution
<!-- Description of the changes that resolved the above issue -->
Replace `Utils::getClass()` calls with the native php function `get_class()`.

### Dependencies
<!-- Other PRs that this PR depends on -->
N/A

### Test procedures
<!-- Step by step guide for testing this PR -->
NA

### Links
N/A

## Deployment

### Migrations
No

### Environment variables
<!-- A list of any new/changed environment variables and where to find the correct value -->
<!-- Don't put keys in here. Place them in 1password or Slack -->

### Deployment notes
<!-- Any additional notes about deployment, such as one-off artisan commands that should be run or new cron jobs -->
